### PR TITLE
Bug #0011704 / PHP 7 can't decode empty JSON

### DIFF
--- a/tine20/Tinebase/Frontend/Json.php
+++ b/tine20/Tinebase/Frontend/Json.php
@@ -929,7 +929,7 @@ class Tinebase_Frontend_Json extends Tinebase_Frontend_Json_Abstract
      */
     public function searchPreferencesForApplication($applicationName, $filter)
     {
-        $decodedFilter = is_array($filter) ? $filter : Zend_Json::decode($filter);
+        $decodedFilter = $this->_prepareParameter($filter);
         
         $filter = new Tinebase_Model_PreferenceFilter();
         if (! empty($decodedFilter)) {
@@ -992,7 +992,7 @@ class Tinebase_Frontend_Json extends Tinebase_Frontend_Json_Abstract
      */
     public function savePreferences($data, $adminMode)
     {
-        $decodedData = is_array($data) ? $data : Zend_Json::decode($data);
+        $decodedData = $this->_prepareParameter($data);
         
         $result = array();
         foreach ($decodedData as $applicationName => $data) {


### PR DESCRIPTION
Second try from a clean repository. Added an additional file.

[Bug Report](https://forge.tine20.org/view.php?id=11704)

Function parameters are passed as json or object from time to time. At least PHP 7 (tested) can't handle empty strings as JSON; propably PHP 5.6.5 as well (https://bugs.php.net/bug.php?id=68938).
