### PR TITLE
Fix test requests for Calendar in PHP 7 (see comments in Bug #11704)

### DIFF
--- a/tine20/Calendar/Frontend/Json.php
+++ b/tine20/Calendar/Frontend/Json.php
@@ -289,7 +289,7 @@ class Calendar_Frontend_Json extends Tinebase_Frontend_Json_Abstract
     {
         $controller = Calendar_Controller_Event::getInstance();
         
-        $decodedPagination = is_array($paging) ? $paging : Zend_Json::decode($paging);
+        $decodedPagination = $this->_prepareParameter($paging);
         $pagination = new Tinebase_Model_Pagination($decodedPagination);
         $clientFilter = $filter = $this->_decodeFilter($filter, 'Calendar_Model_EventFilter');
 


### PR DESCRIPTION
Prepare empty parameter for search filter in Calendar (Zend_Json::decode/PHP 7)

Although it is only the test jobs that invoke the function with parameter NULL it is nicer to clean Calender's function rather than changing the tests. I couldn't reproduce a situation in which Tine 2.0's Json Interface requests an empty paging parameter. 