### PR TITLE
Php72upgrade

### DIFF
--- a/tine20/Felamimail/Controller/Account.php
+++ b/tine20/Felamimail/Controller/Account.php
@@ -163,9 +163,9 @@ class Felamimail_Controller_Account extends Tinebase_Controller_Record_Abstract
      * @param int $_containerId
      * @return Felamimail_Model_Account
      */
-    public function get($_id, $_containerId = NULL)
+    public function get($_id, $_containerId = NULL, $_getRelatedData = true, $_getDeleted = false)
     {
-        $record = parent::get($_id, $_containerId);
+        $record = parent::get($_id, $_containerId, $_getRelatedData, $_getDeleted);
         
         if ($record->type == Felamimail_Model_Account::TYPE_SYSTEM) {
             $this->_addSystemAccountConfigValues($record);

--- a/tine20/Filemanager/Controller/Node.php
+++ b/tine20/Filemanager/Controller/Node.php
@@ -101,7 +101,7 @@ class Filemanager_Controller_Node extends Tinebase_Controller_Record_Abstract
      * (non-PHPdoc)
      * @see Tinebase_Controller_Record_Abstract::update()
      */
-    public function update(Tinebase_Record_Interface $_record)
+    public function update(Tinebase_Record_Interface $_record, $_duplicateCheck = true)
     {
         // be careful, don't put $_record in here, like that parent_id might be spoofed! It must be only the id!
         $path = Tinebase_Model_Tree_Node_Path::createFromStatPath(
@@ -159,7 +159,7 @@ class Filemanager_Controller_Node extends Tinebase_Controller_Record_Abstract
             }
         }
 
-        return parent::update($_record);
+        return parent::update($_record, $_duplicateCheck);
     }
     
     /**
@@ -250,15 +250,16 @@ class Filemanager_Controller_Node extends Tinebase_Controller_Record_Abstract
      * 
      * @return  Tinebase_Record_RecordSet
      */
-    public function getMultiple($_ids)
+    public function getMultiple($_ids, $_ignoreACL = false)
     {
-        foreach (($results = $this->_backend->getMultipleTreeNodes($_ids)) as $node) {
+        foreach (($results = $this->_backend->getMultipleTreeNodes($_ids, $_ignoreACL)) as $node) {
             $path = Tinebase_Model_Tree_Node_Path::createFromStatPath(
                 $this->_backend->getPathOfNode($node->getId(), true));
             if (! $this->_backend->checkPathACL($path, 'get', true, false)) {
                 $results->removeRecord($node);
             }
         }
+        $results = $this->_backend->getMultipleTreeNodes($_ids, $_ignoreACL);
         $this->resolveMultipleTreeNodesPath($results);
         return $results;
     }
@@ -289,16 +290,15 @@ class Filemanager_Controller_Node extends Tinebase_Controller_Record_Abstract
      * (non-PHPdoc)
      * @see Tinebase_Controller_Record_Abstract::get()
      */
-    public function get($_id, $_containerId = NULL)
+    public function get($_id, $_containerId = NULL, $_getRelatedData = true, $_getDeleted = false)
     {
         /** @var Tinebase_Model_Tree_Node $record */
-        $record = parent::get($_id);
+        $record = parent::get($_id, _getRelatedData, $_getDeleted);
         $nodePath = Tinebase_Model_Tree_Node_Path::createFromStatPath($this->_backend->getPathOfNode($record, true));
 
         $this->_backend->checkPathACL($nodePath, 'get');
 
         $record->notes = Tinebase_Notes::getInstance()->getNotesOfRecord(Tinebase_Model_Tree_Node::class, $record->getId());
-
 
         $record->path = Tinebase_Model_Tree_Node_Path::removeAppIdFromPath($nodePath->flatpath, $this->_applicationName);
         $this->resolveGrants($record);

--- a/tine20/Tasks/Controller/Task.php
+++ b/tine20/Tasks/Controller/Task.php
@@ -85,12 +85,12 @@ class Tasks_Controller_Task extends Tinebase_Controller_Record_Abstract implemen
      * @throws  Tinebase_Exception_AccessDenied
      * @throws  Tinebase_Exception_Record_Validation
      */
-    public function create(Tinebase_Record_Interface $_task)
+    public function create(Tinebase_Record_Interface $_task, $_duplicateCheck = true)
     {
         $this->_handleCompleted($_task);
         $_task->originator_tz = $_task->originator_tz ? $_task->originator_tz : Tinebase_Core::getUserTimezone();
         
-        $task = parent::create($_task);
+        $task = parent::create($_task, $_duplicateCheck);
         
         $this->_addAutomaticAlarms($task);
         
@@ -143,10 +143,10 @@ class Tasks_Controller_Task extends Tinebase_Controller_Record_Abstract implemen
      * @throws  Tinebase_Exception_AccessDenied
      * @throws  Tinebase_Exception_Record_Validation
      */
-    public function update(Tinebase_Record_Interface $_task)
+    public function update(Tinebase_Record_Interface $_task, $_duplicateCheck = true)
     {
         $this->_handleCompleted($_task);
-        return parent::update($_task);
+        return parent::update($_task, $_duplicateCheck);
     }
     
     /**

--- a/tine20/Tinebase/Acl/Roles.php
+++ b/tine20/Tinebase/Acl/Roles.php
@@ -277,9 +277,9 @@ class Tinebase_Acl_Roles extends Tinebase_Controller_Record_Abstract
      * @param string|array $_ids Ids
      * @return Tinebase_Record_RecordSet
      */
-    public function getMultiple($_ids)
+    public function getMultiple($_ids, $_ignoreACL = false)
     {
-        return $this->_getRolesBackend()->getMultiple($_ids);
+        return $this->_getRolesBackend()->getMultiple($_ids, $_ignoreACL);
     }
     
     /**


### PR DESCRIPTION
Fixes issues of deprecated calls in PHP 7.2 like each()
ref http://php.net/manual/en/migration72.deprecated.php

and calls of implementations of abstract or interafce classes
with optional parameters now have to match

IMPORTANT: This commit only updates Tinebase, Felamimail, Calendar, Tasks and Filemanager