### PR TITLE
Enhancement to simpleMail Smtp-Backend: Remove left over data if user is deleted

### DIFF
--- a/tine20/Tinebase/EmailUser/Smtp/LdapSimpleMailSchema/README
+++ b/tine20/Tinebase/EmailUser/Smtp/LdapSimpleMailSchema/README
@@ -41,11 +41,11 @@ LIMITATION: You need to store Tine 2.0's accounts and your mail settings in
 CONFIGURATION
 
 Currently there's no possibility to use GUI, therefore you need to configure
-simpleMail backend manually. You may select the pattern “simpleMail” within
-Tine 2.0 Setup (setup.php) but to make it fly you need to add options to the
-configuration key “smtp” which is an javascript object (json) and can be
-accessed by the command line interface (cli) or directly in SQL-DB table
-tine20_config. 
+simpleMail backend manually. You may select the backend option “simpleMail” 
+within Tine 2.0 Setup (setup.php) but to make it fly you need to add further 
+options to the configuration key “smtp” which is an javascript object (json) 
+and can be accessed by the command line interface (cli) or directly in SQL-DB 
+table tine20_config. 
 
 simpleMail settings are stored within the json being themselves such an json
 object:
@@ -68,7 +68,7 @@ To set new SMTP config by cli:
 
 OPTIONS - All available options for JSON
 
-[madatory] base:
+[mandatory] base:
 Search base in LDAP for mail information (default search in subtree) and
 default branch to store new entries (see storage_base)
 
@@ -132,7 +132,7 @@ specific part of json is shown)
 1) Get information readonly from anywhere below a specific part of the
 LDAP-tree (default entries here match the LDAP scheme “simpleMail”):
 
-	    "simplemail":{ 
+            "simplemail":{ 
               "base":"ou=mail,ou=config,dc=example,dc=com",
               "readonly":true 
             }
@@ -140,10 +140,10 @@ LDAP-tree (default entries here match the LDAP scheme “simpleMail”):
   Hint: If you manage mail settings aside Tine 2.0 this is how you get your
         aliases known to Felamimail. 
 
-2) Read entries from subtree and write them below specified place, provide the
-necessary information about your DN structure needed for proper searches and 
-for saving new. Be aware of the mailUserDN attribute which holds the link to 
-user's DN:
+2) Read entries from subtree and write them below specified place; provide the
+necessary information about your DN structure - needed for proper searches and 
+for saving new mail properties. Be aware of the mailUserDN attribute which 
+holds the relation to user's DN:
 
             "simplemail":{ 
               "base":"ou=mail,ou=config,dc=example,dc=com", 
@@ -179,5 +179,4 @@ FURTHER READINGS
 
 - Tine 2.0 cli functions https://wiki.tine20.org/CLI_Functions
 
-
-
+Edited 2017-10-22, small changes and typos. 

--- a/tine20/Tinebase/User/Ldap.php
+++ b/tine20/Tinebase/User/Ldap.php
@@ -613,11 +613,15 @@ class Tinebase_User_Ldap extends Tinebase_User_Sql implements Tinebase_User_Inte
         
         try {
             $metaData = $this->_getMetaData($_userId);
-    
+
             if (! empty($metaData['dn'])) {
                 if (Tinebase_Core::isLogLevel(Zend_Log::INFO)) Tinebase_Core::getLogger()->info(__METHOD__ . '::' . __LINE__ 
                     . ' delete user ' . $metaData['dn'] .' from sync backend (LDAP)');
                 $this->_ldap->delete($metaData['dn']);
+            }
+
+            foreach ($this->_ldapPlugins as $plugin) {
+                $plugin->inspectDeleteUser($_userId);
             }
         } catch (Tinebase_Exception_NotFound $tenf) {
             if (Tinebase_Core::isLogLevel(Zend_Log::WARN)) Tinebase_Core::getLogger()->warn(__METHOD__ . '::' . __LINE__

--- a/tine20/Tinebase/User/Plugin/LdapAbstract.php
+++ b/tine20/Tinebase/User/Plugin/LdapAbstract.php
@@ -85,6 +85,16 @@ abstract class Tinebase_User_Plugin_LdapAbstract implements Tinebase_User_Plugin
     }
 
     /**
+     * @param Tinebase_Model_FullUser $_user
+     */
+    public function inspectDeleteUser(Tinebase_Model_FullUser $_user)
+    {
+    	/* this function is empty on purpose: need to provide valid target for 
+    	 * Tinebase_User_Ldap, line 623. If needed other extensions (backends) 
+    	 * can inherit this target if needed. 
+    	 */ 
+    }
+    /**
      * @param Tinebase_Model_User $_user
      * @param array $_ldapEntry
      */


### PR DESCRIPTION
Dear devs, I'd like to bring the latest changes to my backend upstream. Thank you. 

**Please note:** I put the changes into two different commits that you can evaluate commit a002438 separately because this changes _Tinebase/User/Ldap.php_ and _Tinebase/User/Plugin/LdapAbstract.php_ slightly. The reason is that ldap plugins (sync backends) didn't offer a trigger if an user is deleted (unlike SQL backends do). I added one hopefully in a way that does not interfere with the other plugins (the added function is limited to abstract of class that only those classes which need it may inherit the additional function). 