### PR TITLE
0011912: configure timezone of log timestamp

### DIFF
--- a/tine20/Tinebase/Core.php
+++ b/tine20/Tinebase/Core.php
@@ -647,6 +647,7 @@ class Tinebase_Core
         
         if (isset($config->logger) && $config->logger->active) {
             try {
+                $logger->setTimezone($config->logger->tz);
                 $logger->addWriterByConfig($config->logger);
                 if ($config->logger->additionalWriters) {
                     foreach ($config->logger->additionalWriters as $writerConfig) {

--- a/tine20/Tinebase/Log.php
+++ b/tine20/Tinebase/Log.php
@@ -36,6 +36,12 @@ class Tinebase_Log extends Zend_Log
     protected $_flippedPriorities;
 
     /**
+     * Stores timezone information
+     * @var string
+     */
+    protected $_tz = NULL;
+
+    /**
      * Class constructor.  Create a new logger
      *
      * @param Zend_Log_Writer_Abstract|null  $writer  default writer
@@ -157,5 +163,47 @@ class Tinebase_Log extends Zend_Log
             }
         }
         return $logLevel;
+    }
+
+    /**
+     * Log a message at a priority
+     *
+     * @param  string   $message   Message to log
+     * @param  integer  $priority  Priority of message
+     * @param  mixed    $extras    Extra information to log in event
+     * @return void
+     * @throws Zend_Log_Exception
+     */
+    public function log($message, $priority, $extras = null)
+    {
+        if ($this->_tz){
+            $oldTZ = date_default_timezone_get();
+            date_default_timezone_set($this->_tz);
+            parent::log($message, $priority, $extras);
+            date_default_timezone_set($oldTZ);
+        }
+        else
+            parent::log($message, $priority, $extras);
+    }
+
+    /**
+     * Sets the timezone for the log output
+     *
+     * @param  string   $_tz   valid PHP timezone or NULL for UTC
+     * @return void
+     */
+    public function setTimezone($_tz)
+    {
+        $this->_tz = $_tz;
+    }
+
+    /**
+     * Returns the timezone for the log output
+     *
+     * @return  string   $_tz   valid PHP timezone or NULL for UTC
+     */
+    public function getTimezone()
+    {
+        return($this->_tz);
     }
 }


### PR DESCRIPTION
Adds support for logging in local timezone.
Timezone can be set in config.inc.php as an option
for logger, ie:

  'logger' =>
  array (
    'active' => true,
    'priority' => 4, //warnings and above
    'filename' => '/var/tine20/log/tine20.log',
    'colorize' => true, //show output in priority colours
    'tz' => 'Pacific/Auckland', //define log timezone
    //'syslog' => true,
  ),

Solves issue 0011912