### PR TITLE
0013582: Tine sends an invalid VTODO during sync, when a task is marked as done

### DIFF
--- a/tine20/Tasks/Convert/Task/VCalendar/Abstract.php
+++ b/tine20/Tasks/Convert/Task/VCalendar/Abstract.php
@@ -98,7 +98,7 @@ class Tasks_Convert_Task_VCalendar_Abstract extends Tinebase_Convert_VCalendar_A
         }
         
         if(isset($task->completed)){
-             $vtodo->add('COMPLETED', $task->completed);
+            $vtodo->add('COMPLETED', $task->completed->getClone()->setTimezone('UTC'));
         }
 
         switch($task->priority) {


### PR DESCRIPTION
Tine20 sets the COMPLETED property incorrectly as a local time with TZID. According to the spec, this should be in UTC.