### PR TITLE
Misused php header causes malformed headers

### DIFF
--- a/tine20/status.php
+++ b/tine20/status.php
@@ -16,5 +16,5 @@ $values = array(
     'edition'       => ''
 );
 
-header('Content-Type', 'application/json');
+header('Content-Type: application/json');
 echo(json_encode($values));


### PR DESCRIPTION
The command "header('Content-Type', 'application/json');" is simply wrong, see php manual. The header including value is first parameter. Breaks since a later Apache 2.4 update (checking for malformatted headers for security reasons). Affects only owncloud clients. 