### PR TITLE
Quota is handled as MByte internally now

### DIFF
--- a/tine20/Tinebase/EmailUser/Imap/Cyrus.php
+++ b/tine20/Tinebase/EmailUser/Imap/Cyrus.php
@@ -128,8 +128,8 @@ class Tinebase_EmailUser_Imap_Cyrus extends Tinebase_User_Plugin_Abstract implem
         $emailUser = new Tinebase_Model_EmailUser(array(
             'emailUsername'  => $this->_appendDomain($_user->accountLoginName),
             'emailUserId'    => $this->_appendDomain($_user->accountLoginName),
-            'emailMailQuota' => isset($quota['STORAGE']) ? round($quota['STORAGE']['limit'] / 1024) : null,
-            'emailMailSize'  => isset($quota['STORAGE']) ? round($quota['STORAGE']['usage'] / 1024) : null,
+            'emailMailQuota' => isset($quota['STORAGE']) ? round($quota['STORAGE']['limit'] * 1024) : null,
+            'emailMailSize'  => isset($quota['STORAGE']) ? round($quota['STORAGE']['usage'] * 1024) : null,
             'emailHost'     => $this->_config['host'],
             'emailPort'     => $this->_config['port'],
             'emailSecure'   => $this->_config['ssl'],


### PR DESCRIPTION
Was Byte before last change (https://github.com/tine20/Tine-2.0-Open-Source-Groupware-and-CRM/commit/b048d69addd4a65b03cc3bb6cbbddb8ad76f03c0#diff-ba2dd7e24d16e2cebec11e699c65ad41). 

Need to adjust to KByte for original IMAP storage (rfc 2087):
STORAGE    Sum of messages' RFC822.SIZE, in units of 1024 octets

Reopened Bug #0013512.