### PR TITLE
Follow-up to fix internal handling of IMAP Quota (Cyrus)

### DIFF
--- a/tine20/Tinebase/EmailUser/Imap/Cyrus.php
+++ b/tine20/Tinebase/EmailUser/Imap/Cyrus.php
@@ -204,7 +204,7 @@ class Tinebase_EmailUser_Imap_Cyrus extends Tinebase_User_Plugin_Abstract implem
         $mailboxString = ($_mailboxString !== NULL) ? $_mailboxString : $this->_getUserMailbox($_user->accountLoginName);
         
         if (isset($_user->imapUser)) {
-            $limit = ($_user->imapUser->emailMailQuota) > 0 ? Tinebase_Helper::convertToBytes($_user->imapUser->emailMailQuota . 'M') / 1024 : null;
+            $limit = ($_user->imapUser->emailMailQuota) > 0 ? $_user->imapUser->emailMailQuota / 1024 : null;
             
             if (Tinebase_Core::isLogLevel(Zend_Log::INFO)) Tinebase_Core::getLogger()->info(__METHOD__ . '::' . __LINE__ 
                 . " Setting quota of user " . $_user->getId() . " to " . $limit);


### PR DESCRIPTION
Prior patch (commit 5aa1623) fixed display of quota already (Tine 2.0 started to use bytes internally). This patch fixes setting/changing of quotas; Cyrus Backend tried to convert MBytes to Bytes, although frontend is already sending bytes. Using bytes globally now.