### PR TITLE
Fix for undefined property access in CRM LeadGridPanel

### DIFF
--- a/tine20/Crm/js/LeadGridPanel.js
+++ b/tine20/Crm/js/LeadGridPanel.js
@@ -198,7 +198,7 @@ Tine.Crm.LeadGridPanel.shortContactRenderer = function(data, type) {
         while (index < data.length && data[index].type != type) {
             index++;
         }
-        if (data[index]) {
+        if (data[index] && data[index].related_record) {
             var org = (data[index].related_record.org_name !== null ) ? data[index].related_record.org_name : '';
             return '<b>' + Ext.util.Format.htmlEncode(org) + '</b><br />' + Ext.util.Format.htmlEncode(data[index].related_record.n_fileas);
         }


### PR DESCRIPTION
After upgrading to 2018.02.3 I got the following JS error in the CRM module:
```
Uncaught TypeError: Cannot read property 'org_name' of undefined
    at Function.Tine.Crm.LeadGridPanel.shortContactRenderer (index.php?method=Tinebase.getJsFiles&de06d4e15369fa439dafa2d02a837614b7bc396d:1)
    at constructor.customerRenderer [as renderer] (index.php?method=Tinebase.getJsFiles&de06d4e15369fa439dafa2d02a837614b7bc396d:1)
    at constructor.doRender (ext-all.js:15)
    at constructor.renderRows (ext-all.js:15)
    at constructor.renderBody (ext-all.js:15)
    at constructor.refresh (ext-all.js:15)
    at constructor.onDataChange (ext-all.js:15)
    at i.Event.fire (ext-all.js:7)
    at constructor.fireEvent (ext-all.js:7)
    at constructor.loadRecords (ext-all.js:7)
```

This PR adds a check to make sure that `related_record` exists.