### PR TITLE
Fix ActiveSync folder type reporting

### DIFF
--- a/tine20/Felamimail/Frontend/ActiveSync.php
+++ b/tine20/Felamimail/Frontend/ActiveSync.php
@@ -979,8 +979,20 @@ class Felamimail_Frontend_ActiveSync extends ActiveSync_Frontend_Abstract implem
         $account = $this->_getAccount();
         
         // first lookup folder type by account settings ...
-        if ($account && !empty($account->ns_personal)) {
-            $personalNameSpaceSuffix = $account->ns_personal . $account->delimiter;
+        if ($account) { 
+            if (!empty($account->ns_personal) {
+                $personalNameSpaceSuffix = $account->ns_personal . $account->delimiter;
+            }
+             
+            if ($account && $account->trash_folder === $folder->globalname)  {
+                return Syncroton_Command_FolderSync::FOLDERTYPE_DELETEDITEMS;
+            }
+            if ($account && $account->sent_folder === $folder->globalname) {
+                return Syncroton_Command_FolderSync::FOLDERTYPE_SENTMAIL;
+            }
+            if ($account && $account->drafts_folder === $folder->globalname) {
+                return Syncroton_Command_FolderSync::FOLDERTYPE_DRAFTS;
+            }
         }
         
         switch (strtoupper($folder->localname)) {
@@ -994,8 +1006,8 @@ class Felamimail_Frontend_ActiveSync extends ActiveSync_Frontend_Abstract implem
                 break;
                 
             case 'TRASH':
-                // either use configured trash folder or detect by name
-                if (($account && $account->trash_folder === $folder->globalname) ||
+                // detect by name if not configured
+                if (($account && $account->trash_folder === $personalNameSpaceSuffix) &&
                     ($personalNameSpaceSuffix . $folder->localname === $folder->globalname)
                 ) {
                     return Syncroton_Command_FolderSync::FOLDERTYPE_DELETEDITEMS;
@@ -1004,8 +1016,8 @@ class Felamimail_Frontend_ActiveSync extends ActiveSync_Frontend_Abstract implem
                 break;
                 
             case 'SENT':
-                // either use configured sent folder or detect by name
-                if (($account && $account->sent_folder === $folder->globalname) ||
+                // detect by name if not configured
+                if (($account && $account->sent_folder === $personalNameSpaceSuffix) &&
                     ($personalNameSpaceSuffix . $folder->localname === $folder->globalname)
                 ) {
                     return Syncroton_Command_FolderSync::FOLDERTYPE_SENTMAIL;
@@ -1014,8 +1026,8 @@ class Felamimail_Frontend_ActiveSync extends ActiveSync_Frontend_Abstract implem
                 break;
                 
             case 'DRAFTS':
-                // either use configured drafts folder or detect by name
-                if (($account && $account->drafts_folder === $folder->globalname) ||
+                // detect by name if not configured
+                if (($account && $account->drafts_folder === $personalNameSpaceSuffix) &&
                     ($personalNameSpaceSuffix . $folder->localname === $folder->globalname)
                 ) {
                     return Syncroton_Command_FolderSync::FOLDERTYPE_DRAFTS;

--- a/tine20/Felamimail/Frontend/ActiveSync.php
+++ b/tine20/Felamimail/Frontend/ActiveSync.php
@@ -984,13 +984,13 @@ class Felamimail_Frontend_ActiveSync extends ActiveSync_Frontend_Abstract implem
                 $personalNameSpaceSuffix = $account->ns_personal . $account->delimiter;
             }
              
-            if ($account && $account->trash_folder === $folder->globalname)  {
+            if ($account->trash_folder === $folder->globalname)  {
                 return Syncroton_Command_FolderSync::FOLDERTYPE_DELETEDITEMS;
             }
-            if ($account && $account->sent_folder === $folder->globalname) {
+            if ($account->sent_folder === $folder->globalname) {
                 return Syncroton_Command_FolderSync::FOLDERTYPE_SENTMAIL;
             }
-            if ($account && $account->drafts_folder === $folder->globalname) {
+            if ($account->drafts_folder === $folder->globalname) {
                 return Syncroton_Command_FolderSync::FOLDERTYPE_DRAFTS;
             }
         }

--- a/tine20/Felamimail/Frontend/ActiveSync.php
+++ b/tine20/Felamimail/Frontend/ActiveSync.php
@@ -980,7 +980,7 @@ class Felamimail_Frontend_ActiveSync extends ActiveSync_Frontend_Abstract implem
         
         // first lookup folder type by account settings ...
         if ($account) { 
-            if (!empty($account->ns_personal) {
+            if (!empty($account->ns_personal)) {
                 $personalNameSpaceSuffix = $account->ns_personal . $account->delimiter;
             }
              


### PR DESCRIPTION
Fix checking folder name when reporting the ActiveSync folder type.

Previously, the check would only run if the localname was the original name (i.e. only moves of custom folders worked).
This change always checks against the account settings first.

--
Hi,
first of all, thanks for the great software!
I am running a setup where the Trash and Sent folders have custom names ('Gelöschte Elemente' from Outlook in German). Felamimail supports these, but reports them incorrectly via ActiveSync because the corresponding check is below the `switch (strtoupper($folder->localname))`. This effectively allows only custom folders at different locations, say `INBOX.something.Trash`.

I try to use the name-detection only if no name is configured, but I'm not certain about the default (unconfigured) value of `$account->sent_folder` etc.